### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,29 @@ iptables -A PREROUTING -t nat -i eth0 -p tcp -m tcp --dport 9735 -j DNAT --to 19
 iptables -A PREROUTING -t nat -i eth0 -p tcp -m tcp --dport 8080 -j DNAT --to 192.168.255.6:8080
 iptables -t nat -A POSTROUTING -d 192.168.255.0/24 -o tun0 -j MASQUERADE
 ```
-save with `:wq` and now your VPS adheres to those rules after a reboot, too.
+
+#### Here's some help on how to use the editor
+
+For practice, leave the editor now
+
+- ESC -> `:q!` -> ENTER -> Exit without saving
+- That :q! you really have to enter it like this
+
+Now the editor opens again
+
+- `vi ovpn_env.sh`
+- set the cursor to the last line -> G (=> capital "G" -> Shift+g)
+- go to edit mode -> a (lowercase "a")
+- wrap a line -> ENTER
+  - now copy the three "iptables" lines from above
+- ESC -> leave editing mode
+  - `:wq` -> save changes and close
+
+##### Then leave the docker again
+
+```
+$ exit
+```
 
 ### LND Node: LND adjustments to listen and channel via VPS VPN Tunnel
 We switch Terminal windows again, going back to your LND Node. A quick disclaimer again, since we are fortunate enough to have plenty of good LND node solutions out there, we cannot cater for every configuration out there. Feel free to leave comments or log issues if you get stuck for your node, we'll be looking at the two most different setups here. But this should work very similar on _MyNode_, _Raspibolt_ or _Citadel_.

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ sudo systemctl enable lnbits.service
 sudo systemctl start lnbits.service
 ```
 
-When this is successful, it'll report your wallet balance of your node, and you can move on. If not, a good debugging approach is to connect from the VPS to your node via `curl https://172.17.0.1:8080 -v --cacert /root/tls.cert`. 
+When this is successful, it'll report your wallet balance of your node, and you can move on. If not, a good debugging approach is to connect from the VPS to your node via `curl https://172.17.0.2:8080 -v --cacert /root/tls.cert`. 
 
 
 LNBits should now be running and listening on all incoming requests on port 5000. If you're impatient, you can `curl https://127.0.0.1:5000` and you should see a text-version of the LNBits UI. Note that because the way we run LNBits only locally, you can't test external access just yet. If `curl` doesn't provide meaningful response, check with the command `netstat -tulpen | grep 5000` to see if your process listening on port 5000.

--- a/README.md
+++ b/README.md
@@ -260,9 +260,9 @@ Your VPS needs operational maintenance, and a reboot sometimes isn't avoidable. 
    - within the container, change the directory `cd /etc/openvpn` and open the environment-settings file for OpenVPN via `vi ovpn_env.sh`. Nano isn't installed in the docker container,  follow the [vi-cheatsheet PDF](https://www.atmos.albany.edu/daes/atmclasses/atm350/vi_cheat_sheet.pdf) if you get confused (and you will). Add the following lines to the file
 
 ```
-$ iptables -A PREROUTING -t nat -i eth0 -p tcp -m tcp --dport 9735 -j DNAT --to 192.168.255.6:9735
-$ iptables -A PREROUTING -t nat -i eth0 -p tcp -m tcp --dport 8080 -j DNAT --to 192.168.255.6:8080
-$ iptables -t nat -A POSTROUTING -d 192.168.255.0/24 -o tun0 -j MASQUERADE
+iptables -A PREROUTING -t nat -i eth0 -p tcp -m tcp --dport 9735 -j DNAT --to 192.168.255.6:9735
+iptables -A PREROUTING -t nat -i eth0 -p tcp -m tcp --dport 8080 -j DNAT --to 192.168.255.6:8080
+iptables -t nat -A POSTROUTING -d 192.168.255.0/24 -o tun0 -j MASQUERADE
 ```
 save with `:wq` and now your VPS adheres to those rules after a reboot, too.
 

--- a/README.md
+++ b/README.md
@@ -263,7 +263,6 @@ Your VPS needs operational maintenance, and a reboot sometimes isn't avoidable. 
 $ iptables -A PREROUTING -t nat -i eth0 -p tcp -m tcp --dport 9735 -j DNAT --to 192.168.255.6:9735
 $ iptables -A PREROUTING -t nat -i eth0 -p tcp -m tcp --dport 8080 -j DNAT --to 192.168.255.6:8080
 $ iptables -t nat -A POSTROUTING -d 192.168.255.0/24 -o tun0 -j MASQUERADE
-$ exit
 ```
 save with `:wq` and now your VPS adheres to those rules after a reboot, too.
 


### PR DESCRIPTION
"$ exit" is only for the docker shell, not for the "ovpn_env.sh"